### PR TITLE
Redirect to login after a 401

### DIFF
--- a/client/src/components/Bio/index.js
+++ b/client/src/components/Bio/index.js
@@ -29,8 +29,23 @@ class Bio extends Component {
 
         this.setState({ name: `${firstName} ${lastName}`, userName, email });
       })
-      .catch(err => {
-        console.log(err);
+      .catch(error => {
+        // Response
+        if (error.response) {
+          if (error.response.status === 401) {
+            this.props.updateState({ loggedIn: false, userId: null });
+            this.props.history.push("/login");
+          }
+          console.log("error.response");
+          console.log(error);
+          // Request
+        } else if (error.request) {
+          console.log("error.request");
+          console.log(error.request);
+        } else {
+          // Something happened in setting up the request that triggered an Error
+          console.log("Error during setting up request", error.message);
+        }
       });
   }
 

--- a/client/src/components/CommentForm/index.js
+++ b/client/src/components/CommentForm/index.js
@@ -28,6 +28,21 @@ class CommentForm extends Component {
         .then(response => {
           this.props.refresh();
           this.setState({ body: "", error: "" });
+        })
+        .catch(error => {
+          // Response
+          if (error.response) {
+            if (error.response.status === 401) return window.location.replace("/login");
+            console.log("error.response");
+            console.log(error);
+            // Request
+          } else if (error.request) {
+            console.log("error.request");
+            console.log(error.request);
+          } else {
+            // Something happened in setting up the request that triggered an Error
+            console.log("Error during setting up request", error.message);
+          }
         });
     }
   };

--- a/client/src/components/Form/Form.js
+++ b/client/src/components/Form/Form.js
@@ -39,9 +39,26 @@ class Form extends Component {
     event.preventDefault();
     const { title, body } = this.state;
     const { userId, history } = this.props;
-    axios.post("/api/post", { title: title, body: body, author: userId }).then(({ data }) => {
-      history.push(`/post/${data._id}`);
-    });
+    axios
+      .post("/api/post", { title: title, body: body, author: userId })
+      .then(({ data }) => {
+        history.push(`/post/${data._id}`);
+      })
+      .catch(error => {
+        // Response
+        if (error.response) {
+          if (error.response.status === 401) return window.location.replace("/login");
+          console.log("error.response");
+          console.log(error);
+          // Request
+        } else if (error.request) {
+          console.log("error.request");
+          console.log(error.request);
+        } else {
+          // Something happened in setting up the request that triggered an Error
+          console.log("Error during setting up request", error.message);
+        }
+      });
   };
 
   render() {

--- a/client/src/components/Post/index.js
+++ b/client/src/components/Post/index.js
@@ -86,11 +86,7 @@ class Post extends Component {
             </div>
           </div>
           <hr />
-          {loggedIn ? (
-            <CommentForm updateState={this.updateState} postId={id} userId={userId} refresh={this.loadPost} />
-          ) : (
-            <div />
-          )}
+          {loggedIn ? <CommentForm postId={id} userId={userId} refresh={this.loadPost} /> : <div />}
           {comments ? <CommentBox comments={comments} /> : <div />}
         </div>
       </div>

--- a/client/src/components/Post/index.js
+++ b/client/src/components/Post/index.js
@@ -16,17 +16,54 @@ class Post extends Component {
 
   loadPost = () => {
     let id = this.props.match.params.id;
-    axios.get("/api/post/" + id).then(res => {
-      this.setState({
-        post: res.data
-      });
-
-      axios.get("/api/user/" + this.state.post.author._id).then(res => {
+    axios
+      .get("/api/post/" + id)
+      .then(res => {
         this.setState({
-          user: res.data
+          post: res.data
         });
+
+        axios
+          .get("/api/user/" + this.state.post.author._id)
+          .then(res => {
+            this.setState({
+              user: res.data
+            });
+          })
+          .catch(error => {
+            // Response
+            if (error.response) {
+              if (error.response.status === 401) return window.location.replace("/login");
+              console.log("error.response");
+              console.log(error);
+              // Request
+            } else if (error.request) {
+              console.log("error.request");
+              console.log(error.request);
+            } else {
+              // Something happened in setting up the request that triggered an Error
+              console.log("Error during setting up request", error.message);
+            }
+          });
+      })
+      .catch(error => {
+        // Response
+        if (error.response) {
+          if (error.response.status === 401) {
+            this.props.updateState({ loggedIn: false, userId: null });
+            this.props.history.push("/login");
+          }
+          console.log("error.response");
+          console.log(error);
+          // Request
+        } else if (error.request) {
+          console.log("error.request");
+          console.log(error.request);
+        } else {
+          // Something happened in setting up the request that triggered an Error
+          console.log("Error during setting up request", error.message);
+        }
       });
-    });
   };
 
   render() {
@@ -49,7 +86,11 @@ class Post extends Component {
             </div>
           </div>
           <hr />
-          {loggedIn ? <CommentForm postId={id} userId={userId} refresh={this.loadPost} /> : <div />}
+          {loggedIn ? (
+            <CommentForm updateState={this.updateState} postId={id} userId={userId} refresh={this.loadPost} />
+          ) : (
+            <div />
+          )}
           {comments ? <CommentBox comments={comments} /> : <div />}
         </div>
       </div>

--- a/client/src/components/Search/index.js
+++ b/client/src/components/Search/index.js
@@ -10,11 +10,28 @@ class Search extends Component {
 
   //axios call to search database
   getPost = () => {
-    axios.get(`/api/post/?query=${this.state.query}`).then(response => {
-      this.setState({
-        results: response.data
+    axios
+      .get(`/api/post/?query=${this.state.query}`)
+      .then(response => {
+        this.setState({
+          results: response.data
+        });
+      })
+      .catch(error => {
+        // Response
+        if (error.response) {
+          if (error.response.status === 401) return window.location.replace("/login");
+          console.log("error.response");
+          console.log(error);
+          // Request
+        } else if (error.request) {
+          console.log("error.request");
+          console.log(error.request);
+        } else {
+          // Something happened in setting up the request that triggered an Error
+          console.log("Error during setting up request", error.message);
+        }
       });
-    });
   };
 
   handleInputChange = () => {

--- a/client/src/components/TopicsContainer/index.js
+++ b/client/src/components/TopicsContainer/index.js
@@ -141,8 +141,21 @@ class TopicsContainer extends Component {
         this.checkFavorites(topics, favourites);
         this.setState({ error: "" });
       })
-      .catch(err => {
-        this.setState({ error: err });
+      .catch(error => {
+        // Response
+        if (error.response) {
+          if (error.response.status === 401) return window.location.replace("/login");
+
+          console.log("error.response");
+          console.log(error);
+          // Request
+        } else if (error.request) {
+          console.log("error.request");
+          console.log(error.request);
+        } else {
+          // Something happened in setting up the request that triggered an Error
+          console.log("Error during setting up request", error.message);
+        }
       });
   };
 

--- a/client/src/components/TopicsContainer/index.js
+++ b/client/src/components/TopicsContainer/index.js
@@ -39,15 +39,33 @@ class TopicsContainer extends Component {
 
     // wait for both preceeding axios calls to finish before proceeding
     // both responses will be push into an array
-    Promise.all(promise).then(responses => {
-      let topics = responses[0].data;
-      let favourites = [];
-      if (loggedIn) {
-        favourites = responses[1].data.favourites;
-      }
+    Promise.all(promise)
+      .then(responses => {
+        console.log("Promise.all responses", responses);
+        let topics = responses[0].data;
+        let favourites = [];
+        if (loggedIn) {
+          favourites = responses[1].data.favourites;
+        }
 
-      this.checkFavorites(topics, favourites);
-    });
+        this.checkFavorites(topics, favourites);
+      })
+      .catch(error => {
+        // Response
+        if (error.response) {
+          if (error.response.status === 401) return window.location.replace("/login");
+
+          console.log("error.response");
+          console.log(error);
+          // Request
+        } else if (error.request) {
+          console.log("error.request");
+          console.log(error.request);
+        } else {
+          // Something happened in setting up the request that triggered an Error
+          console.log("Error during setting up request", error.message);
+        }
+      });
   };
 
   getMyFavouritePosts() {
@@ -78,9 +96,21 @@ class TopicsContainer extends Component {
             console.log(err);
           });
       })
-      .catch(err => {
-        console.log("ERROR retrieiving user's favourite posts");
-        console.log(err);
+      .catch(error => {
+        // Response
+        if (error.response) {
+          if (error.response.status === 401) return window.location.replace("/login");
+
+          console.log("error.response");
+          console.log(error);
+          // Request
+        } else if (error.request) {
+          console.log("error.request");
+          console.log(error.request);
+        } else {
+          // Something happened in setting up the request that triggered an Error
+          console.log("Error during setting up request", error.message);
+        }
       });
   }
 

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -20,7 +20,7 @@ module.exports = app => {
       user.findAll(req, res);
     }
   });
-  app.get("/api/user/:id", ensureAuthenticated, (req, res) => {
+  app.get("/api/user/:id", (req, res) => {
     user.findById(req, res);
   });
   app.post("/api/user", ensureAuthenticated, (req, res) => {

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -5,6 +5,7 @@ const comment = require("../controllers/comment");
 
 function ensureAuthenticated(req, res, next) {
   if (!req.isAuthenticated()) {
+    console.log("401 Unautorized");
     return res.status(401).end("Unauthorized");
   }
   next();
@@ -19,7 +20,7 @@ module.exports = app => {
       user.findAll(req, res);
     }
   });
-  app.get("/api/user/:id", (req, res) => {
+  app.get("/api/user/:id", ensureAuthenticated, (req, res) => {
     user.findById(req, res);
   });
   app.post("/api/user", ensureAuthenticated, (req, res) => {


### PR DESCRIPTION
Did a bunch of tests where a 401 can happen. And added a catch that redirects to /login.
Decided to go with windows.location.replace(). This reloads the app, clears the stale loggedIn flag and userId.

I think the catch can be placed in a separate file and imported.